### PR TITLE
Add check for None argument

### DIFF
--- a/palletjack_sdg/standalone_palletjack_sdg.py
+++ b/palletjack_sdg/standalone_palletjack_sdg.py
@@ -308,10 +308,11 @@ def main():
                             scale=rep.distribution.uniform((0.01, 0.01, 0.01), (0.01, 0.01, 0.01)))
 
         # Modify the pose of all the distractors in the scene
-        with rep_distractor_group:
-            rep.modify.pose(position=rep.distribution.uniform((-6, -6, 0), (6, 12, 0)),
-                                rotation=rep.distribution.uniform((0, 0, 0), (0, 0, 360)),
-                                scale=rep.distribution.uniform(1, 1.5))
+        if args.distractors != "None":
+            with rep_distractor_group:
+                rep.modify.pose(position=rep.distribution.uniform((-6, -6, 0), (6, 12, 0)),
+                                    rotation=rep.distribution.uniform((0, 0, 0), (0, 0, 360)),
+                                    scale=rep.distribution.uniform(1, 1.5))
 
         # Randomize the lighting of the scene
         with rep.get.prims(path_pattern="RectLight"):


### PR DESCRIPTION
### Problem
Running with the `distractors` argument set to None results in the following error
`2025-06-24 22:58:05 [17,952ms] [Error] [omni.kit.app._impl] [py stderr]: /home/sreetz/isaac-sim-standalone@4.5.0-rc.36+release.19112.f59b3005.gl.linux-x86_64.release/extscache/omni.replicator.core-1.11.35+106.5.0.lx64.r.cp310/omni/replicator/core/ogn/python/_impl/nodes/OgnSampleUniform.py:56: UserWarning: Expected inputs:num_samples to be greater than 0 but instead received 0
  warnings.warn(f"Expected inputs:num_samples to be greater than 0 but instead received {num_samples}")`
  
 This was discovered through one of our Isaac Sim courses which uses the following command: `./python.sh $SCRIPT_PATH --height 544 --width 960 --num_frames 1000 --distractors None --data_dir $OUTPUT_NO_DISTRACTORS`
  
###  Fix
 To prevent this, add a check to not process the distractor group if 'None' was passed as an argument.